### PR TITLE
Added support for the SiFive RISC-V gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Available tools:
 - compiler_sparc_rtems_gcc
 - compiler_or1k_aac_rtems_gcc
 - compiler_or32_aac_elf_gcc
-
+- compiler_riscv64_unknown_elf_gcc
 
 ### Build flags
 
@@ -36,7 +36,7 @@ The standard Unix build flags like `CCFLAGS` are split into several
 environment variables. With this the cross compiler can set several
 options while allowing the user to change other parts.
 
-The following environment variables are available: 
+The following environment variables are available:
 
 Options for C and C++ (`CCFLAGS`):
 
@@ -93,7 +93,7 @@ Available tools:
 
 The `setttings_gcc_default_internal` tool is not intended to be used
 by the user but is loaded by the GCC based compilers to define a common
-set of options. 
+set of options.
 
 If the `setttings_gcc_optionsfile` tool is loaded the GCC command line
 options are passed in a temporary file to avoid problems with over-long

--- a/site_tools/compiler_riscv64_unknown_elf_gcc.py
+++ b/site_tools/compiler_riscv64_unknown_elf_gcc.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Benjamin Weps
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+# - 2019 Benjamin Weps
+
+# This is the compiler setup script for the gcc provided by SiFive.
+# Don't get confused about the riscv64 prefix, the compiler supports both
+# 32 and 64 bit targets (the processor width its part of the ISA definition)
+
+from SCons.Script import *
+
+def generate(env, **kw):
+    env['PROGSUFFIX'] = '.elf'
+    env['ARCHITECTURE'] = 'riscv64'
+    env.SetDefault(OS='unknown')
+
+    env.SetDefault(COMPILERPREFIX='riscv64-unknown-elf-')
+    env.SetDefault(RISCV_ISA="rv32imac")
+    env.SetDefault(RISCV_ABI="ilp32")
+
+    env.SetDefault(CCFLAGS_target=[
+        '-march=$RISCV_ISA',
+        "-mabi=$RISCV_ABI",])
+    env.SetDefault(CCFLAGS_debug=['-gdwarf-2'])
+    env.SetDefault(CCFLAGS_optimize=[
+        '-Os',
+        '-ffunction-sections',
+        '-fdata-sections', ])
+    env.SetDefault(CCFLAGS_other=[
+        '-finline-limit=10000',
+        '-funsigned-char',
+        '-funsigned-bitfields',
+        '-fno-split-wide-types',
+        '-fno-move-loop-invariants',
+        '-fno-tree-loop-optimize',
+        '-fno-unwind-tables',
+        '-fshort-wchar',        # Required when using newlib.nano
+        ])
+
+    env.SetDefault(CXXFLAGS_target=[
+        "-march=$RISCV_ISA",
+        "-mabi=$RISCV_ABI"])
+    env.SetDefault(CXXFLAGS_other=[
+        '-fno-threadsafe-statics',
+        '-fuse-cxa-atexit',])
+    env.SetDefault(CXXFLAGS_language=[
+        '-std=c++17',
+        '-fno-exceptions',
+        '-fno-rtti',])
+
+    env.SetDefault(ASFLAGS_target=[
+        "-march=$RISCV_ISA"
+        ])
+
+    env.SetDefault(LINKFLAGS_target=[
+        "-march=$RISCV_ISA",
+        "-mabi=$RISCV_ABI",
+        ])
+    env.SetDefault(LINKFLAGS_optimize=['--gc-sections', ])
+    env.SetDefault(LINKFLAGS_other=[
+        "-Wl,--fatal-warnings",
+        # "-Wl,-Map=project.map,--cref",
+        ])
+
+    env.Tool('settings_gcc_default_internal')
+
+
+def exists(env):
+    return env.Detect('gcc')

--- a/site_tools/utils_buildsize.py
+++ b/site_tools/utils_buildsize.py
@@ -140,7 +140,8 @@ Heap:  {heap_fmt:>11s} ({heap_p:2.1f}% available)
 def show_size(env, source, alias='__size'):
     if env.has_key('CONFIG_DEVICE_MEMORY'):
         action = Action(size_action, cmdstr="$SIZECOMSTR")
-    elif env.has_key('CONFIG_DEVICE_NAME'):
+    elif env.has_key('CONFIG_DEVICE_NAME') and ("avr" in env["ARCHITECTURE"]):
+        # the mcu parameter is an AVR specific feature
         action = Action("$SIZE -C --mcu=$CONFIG_DEVICE_NAME %s" % source[0].path,
                         cmdstr="$SIZECOMSTR")
     else:


### PR DESCRIPTION
This PR will add support for the pre-build RISC-V gcc toolchain by SiFive which can be downloaded here: https://www.sifive.com/boards

A few thing to be mentioned:
- Don't get confused by the riscv64 prefix. This toolchain works for both, 32 and 64 RISC-V target. In fact, the processor width is just a part of the CPU type designation (`RV32I` and `RV64I`) along with the different extensions.
- The size tool of this toolchain does not support the -C parameter, but I couldn't convince the scripts to drop the "CONFIG_DEVICE_NAME" either, so I built a workaround which looks a bit dirty. Any proposals to improve that are welcome